### PR TITLE
Modernize layout and event display

### DIFF
--- a/events/event1.js
+++ b/events/event1.js
@@ -1,16 +1,14 @@
 (() => {
-    // tout ton code dans cette fonction auto-exécutée
-  
-    // exemple :
-    let p = document.createElement('p');
-    p.textContent = "Event 1 activé !";
-    p.classList.add("custom-event-modal");
-    document.body.appendChild(p);
-  
-    // si modal, tu peux aussi définir window.closeCustomEventModal ici
-    window.closeCustomEventModal = () => {
-      p.remove();
-      delete window.closeCustomEventModal;
-    };
-  })();
-  
+  // tout ton code dans cette fonction auto-exécutée
+
+  // exemple :
+  const p = document.createElement('p');
+  p.textContent = "Event 1 activé !";
+  p.classList.add('custom-event-modal');
+  document.body.appendChild(p);
+
+  window.closeCustomEventModal = () => {
+    p.remove();
+    delete window.closeCustomEventModal;
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -9,36 +9,37 @@
 
 </head>
 <body>
-  <div class="container">
-    <h1>Compteur Personnalisable</h1>
+  <div class="container py-5">
+    <div id="mainCard" class="card shadow-sm p-4">
+      <h1 class="mb-4">Compteur Personnalisable</h1>
 
-    <div id="config">
-      <label>
-        Durée totale (en minutes) :
-        <input type="number" id="durationInput" value="210" min="1">
-      </label>
-      <br>
-      <label>
-        Intervalle par carré (en secondes) :
-        <input type="number" id="intervalInput" value="60" min="1">
-      </label>
-      <br>
-      <p id="squareCount">Carrés générés : 0</p>
-      <button id="startButton">Démarrer</button>
+      <div id="config" class="mb-3">
+        <label>
+          Durée totale (en minutes) :
+          <input type="number" id="durationInput" value="210" min="1">
+        </label>
+        <br>
+        <label>
+          Intervalle par carré (en secondes) :
+          <input type="number" id="intervalInput" value="60" min="1">
+        </label>
+        <br>
+        <p id="squareCount">Carrés générés : 0</p>
+        <button id="startButton">Démarrer</button>
+      </div>
+
+      <div id="timer" class="mb-3">--:--:--</div>
+
+      <div id="eventInfo" class="alert alert-info text-center"></div>
+
+      <div id="gridContainer" class="mt-4">
+        <div id="grid"></div>
+      </div>
+
     </div>
 
-    <div id="timer">--:--:--</div>
-
-    <div id="eventInfo" class="mt-3 text-center text-primary"></div>
-
-
-    <div id="gridContainer">
-      <div id="grid"></div>
-    </div>
-
-
-  <script src="script.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="script.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -49,7 +49,12 @@ function triggerRandomEvent() {
 
   const eventFile = eventScripts[Math.floor(Math.random() * eventScripts.length)];
   const eventInfo = document.getElementById("eventInfo");
-  if(eventInfo) eventInfo.textContent = `Événement déclenché : ${eventFile}`;
+  if(eventInfo) {
+    const eventName = eventFile.split("/").pop().replace(/\.js$/, "");
+    eventInfo.textContent = `Événement : ${eventName}`;
+    eventInfo.classList.add("show");
+    setTimeout(() => eventInfo.classList.remove("show"), 4000);
+  }
 
   const script = document.createElement("script");
   // Ajoute un timestamp pour forcer le reload
@@ -77,6 +82,8 @@ function generateSquares() {
     square.classList.add("square");
     grid.appendChild(square);
   }
+  const sc = document.getElementById('squareCount');
+  if (sc) sc.textContent = `Carrés générés : ${numSquares}`;
 }
 
 function startTimer() {

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: #f5f5f5;
+  background: linear-gradient(135deg, #74ebd5 0%, #acb6e5 100%);
   color: #333;
   display: flex;
   justify-content: center;
@@ -15,6 +15,19 @@ body {
   padding: 20px;
   max-width: 1200px;
   width: 100%;
+}
+
+#config {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+#config label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 
 
@@ -68,6 +81,7 @@ h1 {
   border: 1px solid #ccc;
   box-sizing: border-box;
   aspect-ratio: 1 / 1;
+  border-radius: 4px;
 }
 
 /* Pseudo-élément = barre de remplissage verticale */
@@ -120,4 +134,18 @@ h1 {
   max-width: 400px;
   margin-inline: auto;
   overflow-y: scroll; /* au lieu de auto */
+}
+
+#eventInfo {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  pointer-events: none;
+}
+
+#eventInfo.show {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- modernized page layout with Bootstrap card
- show event name as toast-style message
- update gradient background and grid styles
- fix event scripts and show square count

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68517871ad28832798a373324f9ae908