### PR TITLE
Add new interactive events

### DIFF
--- a/events/bubblePop.js
+++ b/events/bubblePop.js
@@ -1,0 +1,66 @@
+(() => {
+  const container = document.createElement('div');
+  container.classList.add('custom-event-modal');
+  Object.assign(container.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    zIndex: 1000,
+    pointerEvents: 'none'
+  });
+  document.body.appendChild(container);
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .bubble {
+      position: absolute;
+      border-radius: 50%;
+      background: rgba(173, 216, 230, 0.7);
+      box-shadow: inset 0 0 10px rgba(255,255,255,0.9);
+      pointer-events: auto;
+      transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+    .bubble.pop {
+      transform: scale(1.5);
+      opacity: 0;
+    }
+  `;
+  document.head.appendChild(style);
+
+  function spawnBubble() {
+    const size = 20 + Math.random() * 40;
+    const bubble = document.createElement('div');
+    bubble.classList.add('bubble');
+    Object.assign(bubble.style, {
+      width: size + 'px',
+      height: size + 'px',
+      left: Math.random() * 100 + '%',
+      bottom: '-50px',
+      pointerEvents: 'auto',
+      transition: 'transform 5s linear, bottom 5s linear, opacity 0.3s ease'
+    });
+    bubble.addEventListener('click', () => {
+      bubble.classList.add('pop');
+      setTimeout(() => bubble.remove(), 300);
+    });
+    container.appendChild(bubble);
+    requestAnimationFrame(() => {
+      bubble.style.bottom = '110%';
+    });
+    setTimeout(() => bubble.remove(), 5200);
+  }
+
+  const interval = setInterval(spawnBubble, 400);
+
+  function cleanup() {
+    clearInterval(interval);
+    container.remove();
+    style.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/flashEffect.js
+++ b/events/flashEffect.js
@@ -1,0 +1,40 @@
+(() => {
+  const overlay = document.createElement('div');
+  overlay.classList.add('custom-event-modal');
+  Object.assign(overlay.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    background: 'white',
+    opacity: 0,
+    pointerEvents: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(overlay);
+
+  const style = document.createElement('style');
+  style.textContent = `
+    @keyframes flash {
+      0%,100% { opacity: 0; }
+      50% { opacity: 1; }
+    }
+    .flash-anim {
+      animation: flash 0.5s linear 3;
+    }
+  `;
+  document.head.appendChild(style);
+
+  overlay.classList.add('flash-anim');
+  overlay.addEventListener('animationend', cleanup);
+
+  function cleanup() {
+    overlay.removeEventListener('animationend', cleanup);
+    overlay.remove();
+    style.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/heartFountain.js
+++ b/events/heartFountain.js
@@ -1,0 +1,53 @@
+(() => {
+  const container = document.createElement('div');
+  container.classList.add('custom-event-modal');
+  Object.assign(container.style, {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(container);
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .heart {
+      position: absolute;
+      color: pink;
+      font-size: 24px;
+      opacity: 0.9;
+      transition: transform 3s linear, opacity 3s linear;
+    }
+  `;
+  document.head.appendChild(style);
+
+  function spawnHeart() {
+    const heart = document.createElement('div');
+    heart.textContent = '❤';
+    heart.classList.add('heart');
+    heart.style.left = Math.random() * 100 + '%';
+    heart.style.bottom = '-20px';
+    container.appendChild(heart);
+    requestAnimationFrame(() => {
+      const dx = (Math.random() * 40 - 20);
+      heart.style.transform = `translate(${dx}px, -${window.innerHeight + 50}px)`;
+      heart.style.opacity = '0';
+    });
+    setTimeout(() => heart.remove(), 3000);
+  }
+
+  const interval = setInterval(spawnHeart, 200);
+
+  function cleanup() {
+    clearInterval(interval);
+    container.remove();
+    style.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/matrixMode.js
+++ b/events/matrixMode.js
@@ -1,0 +1,47 @@
+(() => {
+  const canvas = document.createElement('canvas');
+  canvas.classList.add('custom-event-modal');
+  Object.assign(canvas.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    background: 'black',
+    pointerEvents: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(canvas);
+
+  const ctx = canvas.getContext('2d');
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  const fontSize = 16;
+  const columns = Math.floor(canvas.width / fontSize);
+  const drops = new Array(columns).fill(1);
+
+  function draw() {
+    ctx.fillStyle = 'rgba(0,0,0,0.05)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#0f0';
+    ctx.font = fontSize + 'px monospace';
+    for (let i = 0; i < drops.length; i++) {
+      const text = String.fromCharCode(0x30A0 + Math.random() * 96);
+      ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+      if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) {
+        drops[i] = 0;
+      }
+      drops[i]++;
+    }
+  }
+
+  const interval = setInterval(draw, 50);
+
+  function cleanup() {
+    clearInterval(interval);
+    canvas.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/pixelScreen.js
+++ b/events/pixelScreen.js
@@ -1,0 +1,40 @@
+(() => {
+  const container = document.createElement('div');
+  container.classList.add('custom-event-modal');
+  Object.assign(container.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, 20px)',
+    gridAutoRows: '20px',
+    pointerEvents: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(container);
+
+  for (let i = 0; i < Math.ceil(window.innerWidth / 20) * Math.ceil(window.innerHeight / 20); i++) {
+    const cell = document.createElement('div');
+    container.appendChild(cell);
+  }
+
+  const cells = Array.from(container.children);
+  let flashes = 0;
+  const interval = setInterval(() => {
+    cells.forEach(c => {
+      c.style.backgroundColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6,'0');
+    });
+    flashes++;
+    if (flashes > 10) cleanup();
+  }, 200);
+
+  function cleanup() {
+    clearInterval(interval);
+    container.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/puzzleGame.js
+++ b/events/puzzleGame.js
@@ -1,0 +1,60 @@
+(() => {
+  const overlay = document.createElement('div');
+  overlay.classList.add('custom-event-modal');
+  Object.assign(overlay.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'rgba(0,0,0,0.5)',
+    zIndex: 1000
+  });
+  document.body.appendChild(overlay);
+
+  const grid = document.createElement('div');
+  Object.assign(grid.style, {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 60px)',
+    gap: '5px'
+  });
+  overlay.appendChild(grid);
+
+  const cells = [];
+  for (let i = 0; i < 9; i++) {
+    const cell = document.createElement('div');
+    Object.assign(cell.style, {
+      width: '60px',
+      height: '60px',
+      background: '#ccc',
+      cursor: 'pointer'
+    });
+    cell.addEventListener('click', () => {
+      cell.style.background = cell.style.background === 'steelblue' ? '#ccc' : 'steelblue';
+      checkWin();
+    });
+    grid.appendChild(cell);
+    cells.push(cell);
+  }
+
+  function checkWin() {
+    if (cells.every(c => c.style.background === 'steelblue')) {
+      message.textContent = 'Gagn\xE9!';
+      setTimeout(cleanup, 1000);
+    }
+  }
+
+  const message = document.createElement('div');
+  Object.assign(message.style, {color: 'white', marginTop: '10px', textAlign: 'center', fontSize: '20px'});
+  overlay.appendChild(message);
+
+  function cleanup() {
+    overlay.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/events/starRain.js
+++ b/events/starRain.js
@@ -1,0 +1,54 @@
+(() => {
+  const container = document.createElement('div');
+  container.classList.add('custom-event-modal');
+  Object.assign(container.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    zIndex: 1000
+  });
+  document.body.appendChild(container);
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .shooting-star {
+      position: absolute;
+      color: white;
+      font-size: 20px;
+      filter: drop-shadow(0 0 6px white);
+      opacity: 0.8;
+      transition: transform 2s linear, opacity 2s linear;
+    }
+  `;
+  document.head.appendChild(style);
+
+  function createStar() {
+    const star = document.createElement('div');
+    star.textContent = '★';
+    star.classList.add('shooting-star');
+    star.style.left = Math.random() * 100 + '%';
+    star.style.top = '-20px';
+    container.appendChild(star);
+    requestAnimationFrame(() => {
+      const dx = (Math.random() * 200 - 100);
+      star.style.transform = `translate(${dx}px, ${window.innerHeight + 50}px)`;
+      star.style.opacity = '0';
+    });
+    setTimeout(() => star.remove(), 2000);
+  }
+
+  const interval = setInterval(createStar, 300);
+
+  function cleanup() {
+    clearInterval(interval);
+    container.remove();
+    style.remove();
+    delete window.closeCustomEventModal;
+  }
+
+  window.closeCustomEventModal = cleanup;
+})();

--- a/script.js
+++ b/script.js
@@ -16,7 +16,14 @@ const eventScripts = [
   "events/event8.js",
   "events/event9.js",
   "events/bootstrapTheme.js",
-  "events/duckhunt.js"
+  "events/duckhunt.js",
+  "events/starRain.js",
+  "events/matrixMode.js",
+  "events/bubblePop.js",
+  "events/pixelScreen.js",
+  "events/puzzleGame.js",
+  "events/flashEffect.js",
+  "events/heartFountain.js"
 
 ];
 


### PR DESCRIPTION
## Summary
- implement seven new events: star rain, matrix mode, bubble pop, pixel screen, puzzle game, flash effect, and heart fountain
- register new event scripts in the event list

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68527e169f6483279baa0912694c29d2