### PR TITLE
Remove event info overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
 
       <div id="timer" class="mb-3">--:--:--</div>
 
-      <div id="eventInfo" class="alert alert-info text-center"></div>
 
       <div id="gridContainer" class="mt-4">
         <div id="grid"></div>

--- a/script.js
+++ b/script.js
@@ -77,13 +77,7 @@ function triggerRandomEvent() {
   const eventFile = available[Math.floor(Math.random() * available.length)];
   recentEvents.push(eventFile);
   if (recentEvents.length > 5) recentEvents.shift();
-  const eventInfo = document.getElementById("eventInfo");
-  if(eventInfo) {
-    const eventName = eventFile.split("/").pop().replace(/\.js$/, "");
-    eventInfo.textContent = `Événement : ${eventName}`;
-    eventInfo.classList.add("show");
-    setTimeout(() => eventInfo.classList.remove("show"), 4000);
-  }
+  // Affichage du nom de l'événement supprimé
 
   const script = document.createElement("script");
   // Ajoute un timestamp pour forcer le reload

--- a/style.css
+++ b/style.css
@@ -186,16 +186,3 @@ body.dark-mode .square {
   border-color: #555;
 }
 
-#eventInfo {
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
-  opacity: 0;
-  transition: opacity 0.5s ease;
-  pointer-events: none;
-}
-
-#eventInfo.show {
-  opacity: 1;
-}


### PR DESCRIPTION
## Summary
- remove the event info overlay from the HTML
- strip corresponding JavaScript logic
- drop CSS rules related to the overlay

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685324e98d408327a55f813521d3b9f0