### PR TITLE
Add time-based progress zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,19 @@
         <div id="grid"></div>
       </div>
 
+      <div id="progressZone" class="mt-4">
+        <div class="progress w-100">
+          <div id="timeProgress" class="progress-bar" style="width: 0%"></div>
+        </div>
+      </div>
+
+      <div id="circleZone" class="mt-4">
+        <svg id="progressCircle" viewBox="0 0 120 120">
+          <circle class="bg" cx="60" cy="60" r="54" />
+          <circle id="progressArc" cx="60" cy="60" r="54" />
+        </svg>
+      </div>
+
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,9 @@ const darkModeButton = document.getElementById("darkModeButton");
 const timerDisplay = document.getElementById("timer");
 const durationInput = document.getElementById("durationInput");
 const intervalInput = document.getElementById("intervalInput");
+const progressBar = document.getElementById("timeProgress");
+const progressArc = document.getElementById("progressArc");
+const CIRCUMFERENCE = 339;
 let loadedEventScripts = [];
 let recentEvents = [];
 
@@ -98,6 +101,17 @@ function updateTimerDisplay() {
   const minutes = Math.floor((remaining % 3600) / 60).toString().padStart(2, '0');
   const seconds = (remaining % 60).toString().padStart(2, '0');
   timerDisplay.textContent = `${hours}:${minutes}:${seconds}`;
+
+  if (progressBar && totalSeconds) {
+    const ratio = elapsedSeconds / totalSeconds;
+    progressBar.style.width = `${Math.min(ratio * 100, 100)}%`;
+  }
+
+  if (progressArc && totalSeconds) {
+    const ratio = elapsedSeconds / totalSeconds;
+    const offset = CIRCUMFERENCE - ratio * CIRCUMFERENCE;
+    progressArc.style.strokeDashoffset = offset;
+  }
 }
 
 function generateSquares() {
@@ -154,6 +168,8 @@ function startTimer() {
   isPaused = false;
 
   generateSquares();
+  if (progressBar) progressBar.style.width = '0%';
+  if (progressArc) progressArc.style.strokeDashoffset = CIRCUMFERENCE;
   // Met à jour dynamiquement la durée d'animation en CSS
   const style = document.createElement('style');
   style.innerHTML = `

--- a/style.css
+++ b/style.css
@@ -186,3 +186,53 @@ body.dark-mode .square {
   border-color: #555;
 }
 
+/* Zone de progression lin\E9aire */
+#progressZone .progress {
+  height: 20px;
+  background-color: #e9ecef;
+}
+
+#timeProgress {
+  background-color: #27ae60;
+  transition: width 0.5s linear;
+}
+
+/* Zone de progression circulaire */
+#circleZone {
+  max-width: 200px;
+  margin-inline: auto;
+}
+
+#progressCircle {
+  width: 100%;
+  transform: rotate(-90deg);
+}
+
+#progressCircle circle {
+  fill: none;
+  stroke-width: 10;
+}
+
+#progressCircle .bg {
+  stroke: #e0e0e0;
+}
+
+#progressArc {
+  stroke: #3498db;
+  stroke-dasharray: 339;
+  stroke-dashoffset: 339;
+  transition: stroke-dashoffset 0.5s linear;
+}
+
+body.dark-mode #timeProgress {
+  background-color: #2ecc71;
+}
+
+body.dark-mode #progressCircle .bg {
+  stroke: #444;
+}
+
+body.dark-mode #progressArc {
+  stroke: #9bd3ff;
+}
+


### PR DESCRIPTION
## Summary
- add progress bar and circular progress zones
- show progress synced with timer
- style progress zones for light and dark mode

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685326e0495c8327be1d838c23b79a57